### PR TITLE
Make [is_service] accept numeric service names, used for ports in TLSA

### DIFF
--- a/src/domain_name.ml
+++ b/src/domain_name.ml
@@ -29,18 +29,17 @@ let check_service_label s =
     else
       let slen = String.length srv in
       if slen > 0 && slen <= 15 then
-        (* service must be LDH, at least one alpha char
+        (* service must be LDH,
            hyphen _not_ at begin nor end, no hyphen following a hyphen
            1-15 characters *)
-        let v, a, _ = String.fold_left (fun (valid, alp, h) c ->
-            let alpha = Char.Ascii.is_letter c in
+        let v, _ = String.fold_left (fun (valid, h) c ->
             let h' = c = '-' in
-            let v = alpha || Char.Ascii.is_digit c || h' in
+            let v = Char.Ascii.(is_letter c || is_digit c) || h' in
             let hh = not (h && h') in
-            (v && valid && hh, alp || alpha, h'))
-            (true, false, false) srv
+            (v && valid && hh, h'))
+            (true, false) srv
         in
-        v && a && String.get srv 0 <> '-' && String.get srv (pred slen) <> '-'
+        v && String.get srv 0 <> '-' && String.get srv (pred slen) <> '-'
       else
         false
 

--- a/src/domain_name.mli
+++ b/src/domain_name.mli
@@ -60,13 +60,17 @@ val is_hostname : t -> bool
     digits, letters, or hyphens. *)
 
 val is_service : t -> bool
-(** [is_service t] is [true] if [t] is a service label: the first label is a
-    service name (containing of letters, digits, hyphens) prefixed with "_".
-    The service name may not contain a hyphen following another hyphen, no hypen
-    at the beginning or end, and must contain at least one letter.  The total
-    length must be between 1 and at most 15 characters.  The second label is the
-    protocol, prefixed by "_" (at the moment, tcp, udp, or sctp), and the
-    remaining must be a host name. *)
+(** [is_service t] is [true] if [t] contains a service label - if:
+    The first label is a service name (or port number); an underscore preceding
+    1-15 characters from the set [- a-z A-Z 0-9].
+    The service name may not contain a hyphen ([-]) following another hyphen;
+    no hyphen at the beginning or end.
+
+    The second label is the protocol, one of [_tcp], [_udp], or [_sctp].
+    The remaining labels must form a valid hostname.
+
+    This function can be used to validate RR's of the types SRV (RFC 2782)
+    and TLSA (RFC 7671). *)
 
 val sub : subdomain:t -> domain:t -> bool
 (** [sub ~subdomain ~domain] is [true] if [subdomain] contains any labels

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -21,6 +21,8 @@ let basic_preds () =
               (Domain_name.is_service (n_of_s ~hostname:false "_xmpp_server._tcp.foo"))) ;
   Alcotest.(check bool "_xmpp-server-server._tcp.foo is no service" false
               (Domain_name.is_service (n_of_s ~hostname:false "_xmpp_server-server._tcp.foo"))) ;
+  Alcotest.(check bool "_443._tcp.foo is a service" true
+              (Domain_name.is_service (n_of_s ~hostname:false "_443._tcp.foo"))) ;
   Alcotest.(check bool "foo is no subdomain of foo.bar" false
               (Domain_name.sub ~subdomain:(n_of_s "foo") ~domain:(n_of_s "foo.bar"))) ;
   Alcotest.(check bool "foo is a subdomain of foo" true


### PR DESCRIPTION
This make `is_service` usable for validating TLSA service names too.

For reference, some RFCs:
https://tools.ietf.org/html/rfc2782#page-7
https://tools.ietf.org/html/rfc6698#section-2.3
https://tools.ietf.org/html/rfc6698#section-3
