### PR TITLE
Root

### DIFF
--- a/domain_name.ml
+++ b/domain_name.ml
@@ -22,7 +22,6 @@ let for_all p s =
   loop 0
 
 let exists p s =
-  compare p p = 1 &&
   let n = String.length s in
   let rec loop i =
     if i = n then false

--- a/domain_name.ml
+++ b/domain_name.ml
@@ -174,9 +174,13 @@ let of_strings xs =
   try Ok (of_strings_exn xs) with
   | Invalid_argument e -> Error (`Msg e)
 
-let of_string s = of_strings (String.split_on_char '.' s)
+let of_string_exn = function
+  | "." -> root
+  | s -> of_strings_exn (String.split_on_char '.' s)
 
-let of_string_exn s = of_strings_exn (String.split_on_char '.' s)
+let of_string s =
+  try Ok (of_string_exn s) with
+  | Invalid_argument e -> Error (`Msg e)
 
 let of_array a = a
 
@@ -186,7 +190,10 @@ let to_strings ?(trailing = false) dn =
   let labels = Array.to_list dn in
   List.rev (if trailing then "" :: labels else labels)
 
-let to_string ?trailing dn = String.concat "." (to_strings ?trailing dn)
+let to_string ?trailing dn =
+  match to_strings ?trailing dn with
+  | [""] -> "."
+  | labels -> String.concat "." labels
 
 let canonical t =
   let str = to_string t in

--- a/tests.ml
+++ b/tests.ml
@@ -158,14 +158,25 @@ let fqdn () =
               true
               Domain_name.(equal
                              (of_strings_exn [ "example" ; "com" ])
-                             (of_strings_exn [ "example" ; "com" ; "" ])))
+                             (of_strings_exn [ "example" ; "com" ; "" ])));
+  try
+    Alcotest.(check bool {|of_string_exn "" = of_string_exn "."|})
+      true
+      Domain_name.(equal (n_of_s "") (n_of_s "."))
+  with Invalid_argument _ -> Alcotest.fail "invalid domain name for root"
 
 let fqdn_around () =
   let d = n_of_s "foo.com." in
   Alcotest.(check bool "of_string (to_string (of_string 'foo.com.')) works"
               true Domain_name.(equal d (of_string_exn (to_string d)))) ;
   Alcotest.(check bool "of_string (to_string ~trailing:true (of_string 'foo.com.')) works"
-              true Domain_name.(equal d (of_string_exn (to_string ~trailing:true d))))
+              true Domain_name.(equal d (of_string_exn (to_string ~trailing:true d))));
+  try
+    Alcotest.(check bool "of_string (to_string ~trailing:true (of_string '.')) works")
+      true
+      Domain_name.(equal root (of_string_exn (to_string ~trailing:true root)))
+  with Invalid_argument _ -> Alcotest.fail "invalid domain name for root"
+
 
 let drop_labels () =
   let res = n_of_s "foo.com" in


### PR DESCRIPTION
This includes #11 and closes #10.

I wonder if it could make sense to differentiate (explicitly) fully qualified domains to partially qualified domains. I think that could be interesting for some applications, and I think it would afford for not special casing the root domain. Perhaps for another PR.